### PR TITLE
debug: add workflow to investigate flaky layer ordering tests

### DIFF
--- a/.github/scripts/instrument_layer_debug.py
+++ b/.github/scripts/instrument_layer_debug.py
@@ -11,22 +11,33 @@ def patch_file(filepath, replacements):
     with open(filepath, "r") as f:
         content = f.read()
 
-    for old, new in replacements:
+    for i, (old, new) in enumerate(replacements):
         if old not in content:
-            print(f"WARNING: Could not find patch target in {filepath}:")
-            print(f"  Looking for: {old[:80]}...")
+            print(f"FAIL: Could not find patch target #{i} in {filepath}")
+            # Show first 120 chars of what we're looking for
+            print(f"  Looking for: {old[:120]!r}...")
+            # Try to find partial match
+            first_line = old.split("\n")[0].strip()
+            if first_line in content:
+                idx = content.index(first_line)
+                print(f"  First line found at char {idx}, context:")
+                print(repr(content[idx:idx+300]))
+            else:
+                print(f"  First line not found: {first_line!r}")
             sys.exit(1)
-        content = content.replace(old, new)
+        content = content.replace(old, new, 1)
 
     with open(filepath, "w") as f:
         f.write(content)
-    print(f"Patched {filepath}")
+    print(f"Patched {filepath} ({len(replacements)} patches)")
 
 
-# --- Patch layer_downloader.py ---
+# =============================================================================
+# Patch 1: samcli/local/layers/layer_downloader.py
+# =============================================================================
 patch_file("samcli/local/layers/layer_downloader.py", [
+    # 1a: Add debug logging to download_all
     (
-        # Add debug logging to download_all
         '        layer_dirs = []\n'
         '        for layer in layers:\n'
         '            layer_dirs.append(self.download(layer, force))\n'
@@ -47,12 +58,69 @@ patch_file("samcli/local/layers/layer_downloader.py", [
         '\n'
         '        return layer_dirs'
     ),
+    # 1b: Add debug logging to download method - cache check and download path
+    (
+        '        layer_path = Path(self.layer_cache).resolve().joinpath(layer.name)\n'
+        '        is_layer_downloaded = self._is_layer_cached(layer_path)\n'
+        '        layer.codeuri = str(layer_path)\n'
+        '\n'
+        '        if is_layer_downloaded and not force:\n'
+        '            LOG.info("%s is already cached. Skipping download", layer.arn)\n'
+        '            return layer',
+
+        '        layer_path = Path(self.layer_cache).resolve().joinpath(layer.name)\n'
+        '        is_layer_downloaded = self._is_layer_cached(layer_path)\n'
+        '        layer.codeuri = str(layer_path)\n'
+        '        LOG.warning("DEBUG_LAYER_ORDER: download() layer=%s path=%s cached=%s force=%s",\n'
+        '            layer.name, layer_path, is_layer_downloaded, force)\n'
+        '\n'
+        '        if is_layer_downloaded and not force:\n'
+        '            LOG.warning("DEBUG_LAYER_ORDER: SKIPPING download for %s (cached)", layer.arn)\n'
+        '            return layer'
+    ),
+    # 1c: Add debug logging after successful download with content verification
+    (
+        '                unzip_from_uri(\n'
+        '                    layer_zip_uri,\n'
+        '                    layer_zip_path,\n'
+        '                    unzip_output_dir=layer.codeuri,\n'
+        '                    progressbar_label="Downloading {}".format(layer.layer_arn),\n'
+        '                )\n'
+        '\n'
+        '                download_lock.release_lock(success=True)\n'
+        '                return layer',
+
+        '                unzip_from_uri(\n'
+        '                    layer_zip_uri,\n'
+        '                    layer_zip_path,\n'
+        '                    unzip_output_dir=layer.codeuri,\n'
+        '                    progressbar_label="Downloading {}".format(layer.layer_arn),\n'
+        '                )\n'
+        '\n'
+        '                # Debug: verify extracted content\n'
+        '                import os as _os\n'
+        '                for _root, _dirs, _files in _os.walk(layer.codeuri):\n'
+        '                    for _f in _files:\n'
+        '                        _fpath = _os.path.join(_root, _f)\n'
+        '                        if _f.endswith(".py"):\n'
+        '                            try:\n'
+        '                                with open(_fpath) as _fh:\n'
+        '                                    LOG.warning("DEBUG_LAYER_ORDER: extracted %s content: %s",\n'
+        '                                        _fpath, _fh.read().strip())\n'
+        '                            except Exception:\n'
+        '                                pass\n'
+        '\n'
+        '                download_lock.release_lock(success=True)\n'
+        '                return layer'
+    ),
 ])
 
-# --- Patch lambda_image.py ---
+# =============================================================================
+# Patch 2: samcli/local/docker/lambda_image.py
+# =============================================================================
 patch_file("samcli/local/docker/lambda_image.py", [
+    # 2a: Add debug logging to _generate_dockerfile
     (
-        # Add debug logging to _generate_dockerfile
         '        for layer in layers:\n'
         '            dockerfile_content = dockerfile_content + f"ADD {layer.name} {LambdaImage._LAYERS_DIR}\\n"\n'
         '        return dockerfile_content',
@@ -62,8 +130,8 @@ patch_file("samcli/local/docker/lambda_image.py", [
         '        LOG.warning("DEBUG_LAYER_ORDER: Generated Dockerfile:\\n%s", dockerfile_content)\n'
         '        return dockerfile_content'
     ),
+    # 2b: Add debug logging to _build_image tar_paths
     (
-        # Add debug logging to _build_image tar_paths
         '            for layer in layers:\n'
         '                tar_paths[layer.codeuri] = "/" + layer.name\n'
         '\n'
@@ -78,8 +146,8 @@ patch_file("samcli/local/docker/lambda_image.py", [
         '\n'
         '            # Use shared tar filter for Windows compatibility'
     ),
+    # 2c: Add debug logging to build method decision
     (
-        # Add debug logging to build method decision
         '        if (\n'
         '            self.force_image_build\n'
         '            or image_not_found\n'
@@ -100,9 +168,26 @@ patch_file("samcli/local/docker/lambda_image.py", [
         '            or not runtime\n'
         '        ):'
     ),
+    # 2d: Log Docker build stream output to capture cache hits (Using -> CACHED)
+    (
+        '                            # Process stream messages\n'
+        '                            if "stream" in log:\n'
+        '                                stream_msg = log["stream"].strip()\n'
+        '                                if stream_msg:\n'
+        '                                    LOG.debug(f"Build stream: {stream_msg}")',
+
+        '                            # Process stream messages\n'
+        '                            if "stream" in log:\n'
+        '                                stream_msg = log["stream"].strip()\n'
+        '                                if stream_msg:\n'
+        '                                    LOG.warning("DEBUG_LAYER_ORDER: Build stream: %s", stream_msg)\n'
+        '                                    LOG.debug(f"Build stream: {stream_msg}")'
+    ),
 ])
 
-# --- Patch tar.py ---
+# =============================================================================
+# Patch 3: samcli/lib/utils/tar.py
+# =============================================================================
 patch_file("samcli/lib/utils/tar.py", [
     (
         '    with tarfile.open(fileobj=tarballfile, mode=mode, dereference=do_dereferece) as archive:\n'
@@ -116,4 +201,4 @@ patch_file("samcli/lib/utils/tar.py", [
     ),
 ])
 
-print("All files instrumented successfully.")
+print("\nAll files instrumented successfully.")

--- a/.github/scripts/instrument_layer_debug.py
+++ b/.github/scripts/instrument_layer_debug.py
@@ -1,0 +1,119 @@
+"""
+Instrument SAM CLI source files with debug logging for layer ordering investigation.
+This script patches layer_downloader.py, lambda_image.py, and tar.py to emit
+DEBUG_LAYER_ORDER log lines that help diagnose non-deterministic layer ordering.
+"""
+
+import sys
+
+
+def patch_file(filepath, replacements):
+    with open(filepath, "r") as f:
+        content = f.read()
+
+    for old, new in replacements:
+        if old not in content:
+            print(f"WARNING: Could not find patch target in {filepath}:")
+            print(f"  Looking for: {old[:80]}...")
+            sys.exit(1)
+        content = content.replace(old, new)
+
+    with open(filepath, "w") as f:
+        f.write(content)
+    print(f"Patched {filepath}")
+
+
+# --- Patch layer_downloader.py ---
+patch_file("samcli/local/layers/layer_downloader.py", [
+    (
+        # Add debug logging to download_all
+        '        layer_dirs = []\n'
+        '        for layer in layers:\n'
+        '            layer_dirs.append(self.download(layer, force))\n'
+        '\n'
+        '        return layer_dirs',
+
+        '        LOG.warning("DEBUG_LAYER_ORDER: download_all called with %d layers", len(layers))\n'
+        '        for i, layer in enumerate(layers):\n'
+        '            LOG.warning("DEBUG_LAYER_ORDER: input layer[%d] arn=%s name=%s", i, layer.arn, layer.name)\n'
+        '\n'
+        '        layer_dirs = []\n'
+        '        for layer in layers:\n'
+        '            layer_dirs.append(self.download(layer, force))\n'
+        '\n'
+        '        LOG.warning("DEBUG_LAYER_ORDER: download_all returning %d layers", len(layer_dirs))\n'
+        '        for i, layer in enumerate(layer_dirs):\n'
+        '            LOG.warning("DEBUG_LAYER_ORDER: output layer[%d] name=%s codeuri=%s", i, layer.name, layer.codeuri)\n'
+        '\n'
+        '        return layer_dirs'
+    ),
+])
+
+# --- Patch lambda_image.py ---
+patch_file("samcli/local/docker/lambda_image.py", [
+    (
+        # Add debug logging to _generate_dockerfile
+        '        for layer in layers:\n'
+        '            dockerfile_content = dockerfile_content + f"ADD {layer.name} {LambdaImage._LAYERS_DIR}\\n"\n'
+        '        return dockerfile_content',
+
+        '        for layer in layers:\n'
+        '            dockerfile_content = dockerfile_content + f"ADD {layer.name} {LambdaImage._LAYERS_DIR}\\n"\n'
+        '        LOG.warning("DEBUG_LAYER_ORDER: Generated Dockerfile:\\n%s", dockerfile_content)\n'
+        '        return dockerfile_content'
+    ),
+    (
+        # Add debug logging to _build_image tar_paths
+        '            for layer in layers:\n'
+        '                tar_paths[layer.codeuri] = "/" + layer.name\n'
+        '\n'
+        '            # Use shared tar filter for Windows compatibility',
+
+        '            for layer in layers:\n'
+        '                tar_paths[layer.codeuri] = "/" + layer.name\n'
+        '                LOG.warning("DEBUG_LAYER_ORDER: tar_paths entry: %s -> /%s", layer.codeuri, layer.name)\n'
+        '\n'
+        '            LOG.warning("DEBUG_LAYER_ORDER: tar_paths keys order: %s", list(tar_paths.keys()))\n'
+        '            LOG.warning("DEBUG_LAYER_ORDER: tar_paths values order: %s", list(tar_paths.values()))\n'
+        '\n'
+        '            # Use shared tar filter for Windows compatibility'
+    ),
+    (
+        # Add debug logging to build method decision
+        '        if (\n'
+        '            self.force_image_build\n'
+        '            or image_not_found\n'
+        '            or any(layer.is_defined_within_template for layer in downloaded_layers)\n'
+        '            or not runtime\n'
+        '        ):',
+
+        '        LOG.warning(\n'
+        '            "DEBUG_LAYER_ORDER: Build decision - force=%s image_not_found=%s"\n'
+        '            " any_template_layers=%s runtime=%s rapid_image=%s",\n'
+        '            self.force_image_build, image_not_found,\n'
+        '            any(layer.is_defined_within_template for layer in downloaded_layers),\n'
+        '            runtime, rapid_image)\n'
+        '        if (\n'
+        '            self.force_image_build\n'
+        '            or image_not_found\n'
+        '            or any(layer.is_defined_within_template for layer in downloaded_layers)\n'
+        '            or not runtime\n'
+        '        ):'
+    ),
+])
+
+# --- Patch tar.py ---
+patch_file("samcli/lib/utils/tar.py", [
+    (
+        '    with tarfile.open(fileobj=tarballfile, mode=mode, dereference=do_dereferece) as archive:\n'
+        '        for path_on_system, path_in_tarball in tar_paths.items():\n'
+        '            archive.add(path_on_system, arcname=path_in_tarball, filter=tar_filter)',
+
+        '    with tarfile.open(fileobj=tarballfile, mode=mode, dereference=do_dereferece) as archive:\n'
+        '        for path_on_system, path_in_tarball in tar_paths.items():\n'
+        '            LOG.warning("DEBUG_LAYER_ORDER: Adding to tarball: %s -> %s", path_on_system, path_in_tarball)\n'
+        '            archive.add(path_on_system, arcname=path_in_tarball, filter=tar_filter)'
+    ),
+])
+
+print("All files instrumented successfully.")

--- a/.github/workflows/debug-layer-tests.yml
+++ b/.github/workflows/debug-layer-tests.yml
@@ -1,0 +1,283 @@
+name: Debug Layer Order Tests
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_DEFAULT_REGION: us-east-1
+  SAM_CLI_DEV: 1
+  SAM_CLI_TELEMETRY: 0
+  SAM_CLI_CONTAINER_CONNECTION_TIMEOUT: 60
+  NOSE_PARAMETERIZED_NO_WARN: 1
+  BY_CANARY: true
+  UV_PYTHON: python3.11
+  CREDENTIAL_DISTRIBUTION_LAMBDA_ARN: ${{ secrets.CREDENTIAL_DISTRIBUTION_LAMBDA_ARN }}
+  ACCOUNT_RESET_LAMBDA_ARN: ${{ secrets.ACCOUNT_RESET_LAMBDA_ARN }}
+
+jobs:
+  debug-layer-tests:
+    if: github.repository == 'aws/aws-sam-cli'
+    name: Debug Layer Order (${{ matrix.container_runtime }})
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        container_runtime: [docker, finch]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Free up disk space
+        run: |
+          nohup sudo rm -rf /usr/share/dotnet /usr/local/share/powershell /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL &
+          if [ "${{ matrix.container_runtime }}" = "finch" ]; then
+            docker system prune -af --volumes || true
+          else
+            nohup docker system prune -af --volumes || true &
+          fi
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ secrets.OIDC_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Setup Finch runtime
+        if: matrix.container_runtime == 'finch'
+        run: |
+          sudo systemctl stop docker || true
+          sudo systemctl stop docker.socket || true
+          sudo systemctl disable docker || true
+          sudo systemctl disable docker.socket || true
+
+          for i in {1..3}; do
+            if curl -fsSL https://artifact.runfinch.com/deb/GPG_KEY.pub | sudo gpg --dearmor -o /usr/share/keyrings/runfinch-finch-archive-keyring.gpg; then
+              break
+            fi
+            sleep 10
+          done
+
+          echo 'deb [signed-by=/usr/share/keyrings/runfinch-finch-archive-keyring.gpg arch=amd64] https://artifact.runfinch.com/deb noble main' | sudo tee /etc/apt/sources.list.d/runfinch-finch.list
+          sudo apt update
+          sudo apt install -y runfinch-finch
+          sudo systemctl enable --now finch
+          sudo systemctl enable --now finch-buildkit
+          sleep 3
+          sudo chmod 666 /var/run/finch.sock
+
+          for i in {1..12}; do
+            if sudo finch info >/dev/null 2>&1; then
+              break
+            fi
+            sleep 5
+          done
+
+          sudo mkdir -p /run/buildkit-finch /run/buildkit-default /run/buildkit
+          sudo ln -sf /var/lib/finch/buildkit/buildkitd.sock /run/buildkit-finch/buildkitd.sock
+          sudo ln -sf /var/lib/finch/buildkit/buildkitd.sock /run/buildkit-default/buildkitd.sock
+          sudo ln -sf /var/lib/finch/buildkit/buildkitd.sock /run/buildkit/buildkitd.sock
+          sudo chmod 666 /var/lib/finch/buildkit/buildkitd.sock
+          sudo chmod 666 /run/buildkit-*/buildkitd.sock
+          sudo finch run --privileged --rm tonistiigi/binfmt:master --install all
+          sudo finch info
+
+      - name: Setup Docker runtime
+        if: matrix.container_runtime == 'docker'
+        run: |
+          docker info
+          docker version
+
+      - name: Setup QEMU for ARM64 emulation
+        run: |
+          if [ "${{ matrix.container_runtime }}" = "finch" ]; then
+            sudo finch run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          else
+            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          fi
+
+      - name: Initialize project
+        run: |
+          export CONTAINER_RUNTIME=${{ matrix.container_runtime }}
+          make init
+
+      - name: Get testing resources and credentials
+        run: |
+          test_env_var=$(python3.11 tests/get_testing_resources.py skip_role_deletion)
+
+          if [ $? -ne 0 ]; then
+            test_env_var=$(python3.11 tests/get_testing_resources.py)
+            if [ $? -ne 0 ]; then
+              echo "Failed to acquire credentials or test resources."
+              exit 1
+            fi
+          fi
+
+          echo "CI_ACCESS_ROLE_AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" >> $GITHUB_ENV
+          echo "CI_ACCESS_ROLE_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" >> $GITHUB_ENV
+          echo "CI_ACCESS_ROLE_AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN" >> $GITHUB_ENV
+
+          TEST_ACCESS_KEY_ID=$(echo "$test_env_var" | jq -j ".accessKeyID")
+          TEST_SECRET_ACCESS_KEY=$(echo "$test_env_var" | jq -j ".secretAccessKey")
+          TEST_SESSION_TOKEN=$(echo "$test_env_var" | jq -j ".sessionToken")
+          TEST_TASK_TOKEN=$(echo "$test_env_var" | jq -j ".taskToken")
+
+          echo "::add-mask::$TEST_ACCESS_KEY_ID"
+          echo "::add-mask::$TEST_SECRET_ACCESS_KEY"
+          echo "::add-mask::$TEST_SESSION_TOKEN"
+          echo "::add-mask::$TEST_TASK_TOKEN"
+
+          echo "AWS_ACCESS_KEY_ID=$TEST_ACCESS_KEY_ID" >> $GITHUB_ENV
+          echo "AWS_SECRET_ACCESS_KEY=$TEST_SECRET_ACCESS_KEY" >> $GITHUB_ENV
+          echo "AWS_SESSION_TOKEN=$TEST_SESSION_TOKEN" >> $GITHUB_ENV
+          echo "TASK_TOKEN=$TEST_TASK_TOKEN" >> $GITHUB_ENV
+
+          echo "AWS_S3_TESTING=$(echo "$test_env_var" | jq -j ".TestBucketName")" >> $GITHUB_ENV
+          echo "AWS_ECR_TESTING=$(echo "$test_env_var" | jq -j ".TestECRURI")" >> $GITHUB_ENV
+
+      - name: Login to Public ECR
+        run: |
+          if [ "${{ matrix.container_runtime }}" = "finch" ]; then
+            aws ecr-public get-login-password --region us-east-1 | sudo finch login --username AWS --password-stdin public.ecr.aws
+          else
+            aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
+          fi
+
+      - name: Add debug instrumentation
+        run: python3.11 .github/scripts/instrument_layer_debug.py
+
+      - name: Verify instrumentation
+        run: grep -c "DEBUG_LAYER_ORDER" samcli/local/layers/layer_downloader.py samcli/local/docker/lambda_image.py samcli/lib/utils/tar.py
+
+      - name: Run layer order debug tests
+        run: |
+          export CONTAINER_RUNTIME=${{ matrix.container_runtime }}
+
+          echo "============================================"
+          echo "=== Layer zip contents ==="
+          echo "============================================"
+          python3.11 -c "
+          import zipfile, os
+          base = 'tests/integration/testdata/invoke/layer_zips'
+          for zf in ['layer1.zip', 'layer2.zip']:
+              path = os.path.join(base, zf)
+              print(f'=== {zf} ===')
+              with zipfile.ZipFile(path) as z:
+                  for name in z.namelist():
+                      print(f'  {name}')
+                      if name.endswith('.py'):
+                          print(z.read(name).decode())
+          "
+
+          PASS_COUNT=0
+          FAIL_COUNT=0
+
+          for i in $(seq 1 5); do
+            echo ""
+            echo "============================================"
+            echo "=== Iteration $i of 5 ==="
+            echo "============================================"
+
+            rm -rf ~/integ_layer_cache
+
+            echo "--- Cleaning up container images ---"
+            if [ "${{ matrix.container_runtime }}" = "finch" ]; then
+              sudo finch images --format '{{.Repository}}:{{.Tag}}' 2>/dev/null | grep samcli | while read img; do
+                echo "Removing: $img"
+                sudo finch rmi "$img" 2>/dev/null || true
+              done
+            else
+              docker images --format '{{.Repository}}:{{.Tag}}' 2>/dev/null | grep samcli | while read img; do
+                echo "Removing: $img"
+                docker rmi "$img" 2>/dev/null || true
+              done
+              echo "--- Pruning Docker build cache ---"
+              docker builder prune -af 2>/dev/null || true
+            fi
+
+            rm -rf /tmp/*.downloading.lock /tmp/*.downloading.status /tmp/*.building.lock /tmp/*.building.status 2>/dev/null || true
+
+            echo "--- Running test_download_two_layers ---"
+            pytest -vv -s --tb=long --log-cli-level=DEBUG \
+              tests/integration/local/invoke/test_integrations_cli.py \
+              -k "test_download_two_layers" \
+              --json-report --json-report-file=TEST_REPORT-debug-layer-iter${i}-${{ matrix.container_runtime }}.json \
+              2>&1 | tee test_output_iter${i}.log
+
+            TEST_EXIT=$?
+
+            echo ""
+            echo "--- Post-test: layer cache python files ---"
+            find ~/integ_layer_cache -type f -name "*.py" 2>/dev/null -exec echo "=== {} ===" \; -exec cat {} \;
+
+            echo ""
+            echo "--- Post-test: lock/status files ---"
+            find ~/integ_layer_cache -name "*.lock" -o -name "*.status" 2>/dev/null -exec echo "=== {} ===" \; -exec cat {} \;
+
+            echo ""
+            echo "--- Post-test: container images ---"
+            if [ "${{ matrix.container_runtime }}" = "finch" ]; then
+              sudo finch images 2>/dev/null || true
+            else
+              docker images 2>/dev/null | head -20 || true
+            fi
+
+            if [ $TEST_EXIT -eq 0 ]; then
+              PASS_COUNT=$((PASS_COUNT + 1))
+              echo "=== Iteration $i: PASSED ==="
+            else
+              FAIL_COUNT=$((FAIL_COUNT + 1))
+              echo "=== Iteration $i: FAILED ==="
+            fi
+
+            echo ""
+            echo "--- DEBUG_LAYER_ORDER log lines ---"
+            grep "DEBUG_LAYER_ORDER" test_output_iter${i}.log || echo "No DEBUG_LAYER_ORDER lines found"
+
+          done
+
+          echo ""
+          echo "============================================"
+          echo "=== SUMMARY ==="
+          echo "============================================"
+          echo "Passed: $PASS_COUNT / 5"
+          echo "Failed: $FAIL_COUNT / 5"
+
+          if [ $FAIL_COUNT -gt 0 ]; then
+            echo "Some iterations failed - layer ordering is non-deterministic"
+            exit 1
+          fi
+
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: debug-layer-logs-${{ matrix.container_runtime }}
+          path: |
+            test_output_iter*.log
+            TEST_REPORT-debug-layer-*.json
+
+      - name: Reset test account
+        if: always()
+        run: |
+          export AWS_ACCESS_KEY_ID=$CI_ACCESS_ROLE_AWS_ACCESS_KEY_ID
+          export AWS_SECRET_ACCESS_KEY=$CI_ACCESS_ROLE_AWS_SECRET_ACCESS_KEY
+          export AWS_SESSION_TOKEN=$CI_ACCESS_ROLE_AWS_SESSION_TOKEN
+
+          aws lambda invoke \
+            --function-name "$ACCOUNT_RESET_LAMBDA_ARN" \
+            --payload "{\"taskToken\": \"$TASK_TOKEN\", \"output\": \"{}\"}" \
+            ./lambda-output.txt \
+            --region us-west-2 \
+            --cli-binary-format raw-in-base64-out
+
+          cat ./lambda-output.txt

--- a/.github/workflows/debug-layer-tests.yml
+++ b/.github/workflows/debug-layer-tests.yml
@@ -12,6 +12,10 @@ env:
   SAM_CLI_DEV: 1
   SAM_CLI_TELEMETRY: 0
   SAM_CLI_CONTAINER_CONNECTION_TIMEOUT: 60
+  NODE_VERSION: "22.21.1"
+  AWS_S3: "AWS_S3_TESTING"
+  AWS_ECR: "AWS_ECR_TESTING"
+  CARGO_LAMBDA_VERSION: "v0.17.1"
   NOSE_PARAMETERIZED_NO_WARN: 1
   BY_CANARY: true
   UV_PYTHON: python3.11
@@ -21,12 +25,8 @@ env:
 jobs:
   debug-layer-tests:
     if: github.repository == 'aws/aws-sam-cli'
-    name: Debug Layer Order (${{ matrix.container_runtime }})
+    name: Debug Layer Order (docker)
     runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        container_runtime: [docker, finch]
 
     steps:
       - name: Checkout code
@@ -35,11 +35,7 @@ jobs:
       - name: Free up disk space
         run: |
           nohup sudo rm -rf /usr/share/dotnet /usr/local/share/powershell /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL &
-          if [ "${{ matrix.container_runtime }}" = "finch" ]; then
-            docker system prune -af --volumes || true
-          else
-            nohup docker system prune -af --volumes || true &
-          fi
+          nohup docker system prune -af --volumes || true &
 
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v5
@@ -50,65 +46,40 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
-
-      - name: Setup Finch runtime
-        if: matrix.container_runtime == 'finch'
-        run: |
-          sudo systemctl stop docker || true
-          sudo systemctl stop docker.socket || true
-          sudo systemctl disable docker || true
-          sudo systemctl disable docker.socket || true
-
-          for i in {1..3}; do
-            if curl -fsSL https://artifact.runfinch.com/deb/GPG_KEY.pub | sudo gpg --dearmor -o /usr/share/keyrings/runfinch-finch-archive-keyring.gpg; then
-              break
-            fi
-            sleep 10
-          done
-
-          echo 'deb [signed-by=/usr/share/keyrings/runfinch-finch-archive-keyring.gpg arch=amd64] https://artifact.runfinch.com/deb noble main' | sudo tee /etc/apt/sources.list.d/runfinch-finch.list
-          sudo apt update
-          sudo apt install -y runfinch-finch
-          sudo systemctl enable --now finch
-          sudo systemctl enable --now finch-buildkit
-          sleep 3
-          sudo chmod 666 /var/run/finch.sock
-
-          for i in {1..12}; do
-            if sudo finch info >/dev/null 2>&1; then
-              break
-            fi
-            sleep 5
-          done
-
-          sudo mkdir -p /run/buildkit-finch /run/buildkit-default /run/buildkit
-          sudo ln -sf /var/lib/finch/buildkit/buildkitd.sock /run/buildkit-finch/buildkitd.sock
-          sudo ln -sf /var/lib/finch/buildkit/buildkitd.sock /run/buildkit-default/buildkitd.sock
-          sudo ln -sf /var/lib/finch/buildkit/buildkitd.sock /run/buildkit/buildkitd.sock
-          sudo chmod 666 /var/lib/finch/buildkit/buildkitd.sock
-          sudo chmod 666 /run/buildkit-*/buildkitd.sock
-          sudo finch run --privileged --rm tonistiigi/binfmt:master --install all
-          sudo finch info
+          python-version: |
+            3.11
+            3.9
+            3.10
+            3.12
+            3.13
+            3.14
 
       - name: Setup Docker runtime
-        if: matrix.container_runtime == 'docker'
         run: |
           docker info
           docker version
 
       - name: Setup QEMU for ARM64 emulation
+        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
+      - name: Install Terraform
         run: |
-          if [ "${{ matrix.container_runtime }}" = "finch" ]; then
-            sudo finch run --rm --privileged multiarch/qemu-user-static --reset -p yes
-          else
-            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-          fi
+          for i in {1..3}; do
+            TER_VER=$(curl -s https://api.github.com/repos/hashicorp/terraform/releases/latest | grep tag_name | cut -d: -f2 | tr -d \"\,\v | awk '{$1=$1};1')
+            if [ -n "$TER_VER" ]; then
+              if wget https://releases.hashicorp.com/terraform/${TER_VER}/terraform_${TER_VER}_linux_amd64.zip -P /tmp; then
+                sudo unzip -d /opt/terraform /tmp/terraform_${TER_VER}_linux_amd64.zip
+                sudo mv /opt/terraform/terraform /usr/local/bin/
+                terraform -version
+                break
+              fi
+            fi
+            echo "Terraform installation attempt $i failed, retrying..."
+            sleep 5
+          done
 
       - name: Initialize project
-        run: |
-          export CONTAINER_RUNTIME=${{ matrix.container_runtime }}
-          make init
+        run: make init
 
       - name: Get testing resources and credentials
         run: |
@@ -143,14 +114,13 @@ jobs:
 
           echo "AWS_S3_TESTING=$(echo "$test_env_var" | jq -j ".TestBucketName")" >> $GITHUB_ENV
           echo "AWS_ECR_TESTING=$(echo "$test_env_var" | jq -j ".TestECRURI")" >> $GITHUB_ENV
+          echo "AWS_KMS_KEY=$(echo "$test_env_var" | jq -j ".TestKMSKeyArn")" >> $GITHUB_ENV
+          echo "AWS_SIGNING_PROFILE_NAME=$(echo "$test_env_var" | jq -j ".TestSigningProfileName")" >> $GITHUB_ENV
+          echo "AWS_SIGNING_PROFILE_VERSION_ARN=$(echo "$test_env_var" | jq -j ".TestSigningProfileARN")" >> $GITHUB_ENV
 
       - name: Login to Public ECR
         run: |
-          if [ "${{ matrix.container_runtime }}" = "finch" ]; then
-            aws ecr-public get-login-password --region us-east-1 | sudo finch login --username AWS --password-stdin public.ecr.aws
-          else
-            aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
-          fi
+          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
 
       - name: Add debug instrumentation
         run: python3.11 .github/scripts/instrument_layer_debug.py
@@ -158,113 +128,39 @@ jobs:
       - name: Verify instrumentation
         run: grep -c "DEBUG_LAYER_ORDER" samcli/local/layers/layer_downloader.py samcli/local/docker/lambda_image.py samcli/lib/utils/tar.py
 
-      - name: Run layer order debug tests
+      - name: Run original integration tests with debug logging
         run: |
-          export CONTAINER_RUNTIME=${{ matrix.container_runtime }}
+          pytest -vv --reruns 3 \
+            tests/integration/local/invoke \
+            tests/integration/local/generate_event \
+            --ignore tests/integration/local/invoke/test_invoke_durable.py \
+            --log-cli-level=DEBUG \
+            --json-report \
+            --json-report-file=TEST_REPORT-integration-local-invoke-docker.json \
+            2>&1 | tee full_test_output.log
 
-          echo "============================================"
-          echo "=== Layer zip contents ==="
-          echo "============================================"
-          python3.11 -c "
-          import zipfile, os
-          base = 'tests/integration/testdata/invoke/layer_zips'
-          for zf in ['layer1.zip', 'layer2.zip']:
-              path = os.path.join(base, zf)
-              print(f'=== {zf} ===')
-              with zipfile.ZipFile(path) as z:
-                  for name in z.namelist():
-                      print(f'  {name}')
-                      if name.endswith('.py'):
-                          print(z.read(name).decode())
-          "
-
-          PASS_COUNT=0
-          FAIL_COUNT=0
-
-          for i in $(seq 1 5); do
-            echo ""
-            echo "============================================"
-            echo "=== Iteration $i of 5 ==="
-            echo "============================================"
-
-            rm -rf ~/integ_layer_cache
-
-            echo "--- Cleaning up container images ---"
-            if [ "${{ matrix.container_runtime }}" = "finch" ]; then
-              sudo finch images --format '{{.Repository}}:{{.Tag}}' 2>/dev/null | grep samcli | while read img; do
-                echo "Removing: $img"
-                sudo finch rmi "$img" 2>/dev/null || true
-              done
-            else
-              docker images --format '{{.Repository}}:{{.Tag}}' 2>/dev/null | grep samcli | while read img; do
-                echo "Removing: $img"
-                docker rmi "$img" 2>/dev/null || true
-              done
-              echo "--- Pruning Docker build cache ---"
-              docker builder prune -af 2>/dev/null || true
-            fi
-
-            rm -rf /tmp/*.downloading.lock /tmp/*.downloading.status /tmp/*.building.lock /tmp/*.building.status 2>/dev/null || true
-
-            echo "--- Running test_download_two_layers ---"
-            pytest -vv -s --tb=long --log-cli-level=DEBUG \
-              tests/integration/local/invoke/test_integrations_cli.py \
-              -k "test_download_two_layers" \
-              --json-report --json-report-file=TEST_REPORT-debug-layer-iter${i}-${{ matrix.container_runtime }}.json \
-              2>&1 | tee test_output_iter${i}.log
-
-            TEST_EXIT=$?
-
-            echo ""
-            echo "--- Post-test: layer cache python files ---"
-            find ~/integ_layer_cache -type f -name "*.py" 2>/dev/null -exec echo "=== {} ===" \; -exec cat {} \;
-
-            echo ""
-            echo "--- Post-test: lock/status files ---"
-            find ~/integ_layer_cache -name "*.lock" -o -name "*.status" 2>/dev/null -exec echo "=== {} ===" \; -exec cat {} \;
-
-            echo ""
-            echo "--- Post-test: container images ---"
-            if [ "${{ matrix.container_runtime }}" = "finch" ]; then
-              sudo finch images 2>/dev/null || true
-            else
-              docker images 2>/dev/null | head -20 || true
-            fi
-
-            if [ $TEST_EXIT -eq 0 ]; then
-              PASS_COUNT=$((PASS_COUNT + 1))
-              echo "=== Iteration $i: PASSED ==="
-            else
-              FAIL_COUNT=$((FAIL_COUNT + 1))
-              echo "=== Iteration $i: FAILED ==="
-            fi
-
-            echo ""
-            echo "--- DEBUG_LAYER_ORDER log lines ---"
-            grep "DEBUG_LAYER_ORDER" test_output_iter${i}.log || echo "No DEBUG_LAYER_ORDER lines found"
-
-          done
+      - name: Extract debug layer order lines
+        if: always()
+        run: |
+          echo "=== DEBUG_LAYER_ORDER lines ==="
+          grep "DEBUG_LAYER_ORDER" full_test_output.log || echo "No DEBUG_LAYER_ORDER lines found"
 
           echo ""
-          echo "============================================"
-          echo "=== SUMMARY ==="
-          echo "============================================"
-          echo "Passed: $PASS_COUNT / 5"
-          echo "Failed: $FAIL_COUNT / 5"
+          echo "=== Test results summary ==="
+          grep -E "PASSED|FAILED|ERROR" full_test_output.log | grep -i "layer" || true
 
-          if [ $FAIL_COUNT -gt 0 ]; then
-            echo "Some iterations failed - layer ordering is non-deterministic"
-            exit 1
-          fi
+          echo ""
+          echo "=== Docker images after tests ==="
+          docker images | head -30 || true
 
       - name: Upload test logs
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: debug-layer-logs-${{ matrix.container_runtime }}
+          name: debug-layer-logs
           path: |
-            test_output_iter*.log
-            TEST_REPORT-debug-layer-*.json
+            full_test_output.log
+            TEST_REPORT-integration-local-invoke-docker.json
 
       - name: Reset test account
         if: always()

--- a/.github/workflows/debug-layer-tests.yml
+++ b/.github/workflows/debug-layer-tests.yml
@@ -62,22 +62,6 @@ jobs:
       - name: Setup QEMU for ARM64 emulation
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
-      - name: Install Terraform
-        run: |
-          for i in {1..3}; do
-            TER_VER=$(curl -s https://api.github.com/repos/hashicorp/terraform/releases/latest | grep tag_name | cut -d: -f2 | tr -d \"\,\v | awk '{$1=$1};1')
-            if [ -n "$TER_VER" ]; then
-              if wget https://releases.hashicorp.com/terraform/${TER_VER}/terraform_${TER_VER}_linux_amd64.zip -P /tmp; then
-                sudo unzip -d /opt/terraform /tmp/terraform_${TER_VER}_linux_amd64.zip
-                sudo mv /opt/terraform/terraform /usr/local/bin/
-                terraform -version
-                break
-              fi
-            fi
-            echo "Terraform installation attempt $i failed, retrying..."
-            sleep 5
-          done
-
       - name: Initialize project
         run: make init
 
@@ -128,12 +112,11 @@ jobs:
       - name: Verify instrumentation
         run: grep -c "DEBUG_LAYER_ORDER" samcli/local/layers/layer_downloader.py samcli/local/docker/lambda_image.py samcli/lib/utils/tar.py
 
-      - name: Run original integration tests with debug logging
+      - name: Run TestLayerVersion tests with debug logging
         run: |
           pytest -vv --reruns 3 \
-            tests/integration/local/invoke \
-            tests/integration/local/generate_event \
-            --ignore tests/integration/local/invoke/test_invoke_durable.py \
+            tests/integration/local/invoke/test_integrations_cli.py \
+            -k "TestLayerVersion" \
             --log-cli-level=DEBUG \
             --json-report \
             --json-report-file=TEST_REPORT-integration-local-invoke-docker.json \


### PR DESCRIPTION
## Problem
The `test_download_two_layers` integration tests are flaky on Docker (but pass on Finch). They consistently return `"Layer1"` instead of `"Layer2"`, suggesting a layer ordering/overlay issue specific to Docker daemon.

## Changes
- Add a manually-triggered (`workflow_dispatch`) GitHub Actions workflow that runs the `TestLayerVersion` class with debug instrumentation
- Instrumentation script patches SAM CLI source at runtime to log layer ordering at every stage

## What the debug workflow captures
- Layer ordering in `download_all()` input/output
- Per-layer download decisions (cached vs fresh)
- Extracted layer file contents after download
- Generated Dockerfile `ADD` command sequence
- Tarball construction order
- Docker build stream output (cache hits)
- Image build vs reuse decisions

## How to use
Once merged, trigger from Actions tab -> Debug Layer Order Tests -> Run workflow.