### PR TITLE
debug: remove repo guard for fork

### DIFF
--- a/.github/workflows/debug-layer-tests.yml
+++ b/.github/workflows/debug-layer-tests.yml
@@ -24,7 +24,6 @@ env:
 
 jobs:
   debug-layer-tests:
-    if: github.repository == 'aws/aws-sam-cli'
     name: Debug Layer Order (docker)
     runs-on: ubuntu-22.04
 


### PR DESCRIPTION
Remove repo guard so workflow runs on fork