### PR TITLE
fix: preserve original exception context in retry decorator

### DIFF
--- a/samcli/lib/utils/retry.py
+++ b/samcli/lib/utils/retry.py
@@ -26,14 +26,16 @@ def retry(exc, attempts=3, delay=0.05, exc_raise=Exception, exc_raise_msg=""):
         def wrapper(*args, **kwargs):
             remaining_attempts = attempts
             retry_attempt = 1
+            last_exception = None
             while remaining_attempts >= 1:
                 try:
                     return func(*args, **kwargs)
-                except exc:
+                except exc as e:
+                    last_exception = e
                     time.sleep(math.pow(2, retry_attempt) * delay)
                     retry_attempt = retry_attempt + 1
                     remaining_attempts = remaining_attempts - 1
-            raise exc_raise(exc_raise_msg)
+            raise exc_raise(exc_raise_msg) from last_exception
 
         return wrapper
 


### PR DESCRIPTION
Fixes #29 - The retry decorator was swallowing the original exception when all retries were exhausted. The raised exception had no `__cause__`, making it impossible to diagnose the root cause.

Changes:
- Store the last caught exception in the retry loop
- Use `raise ... from last_exception` to preserve the exception chain
- Root cause is now visible in tracebacks